### PR TITLE
Refresh update

### DIFF
--- a/.github/workflows/refresh_statcast_data.yml
+++ b/.github/workflows/refresh_statcast_data.yml
@@ -1,9 +1,9 @@
-name: Update Statcast Data
+name: Refresh Statcast Data
 
 on:
   schedule:
-    # run every day during MLB season months at 12:00 PM ET
-    - cron: '0 17 * 3-11 *'
+    # run every Monday at 12:00 PM ET
+    - cron: '0 17 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -24,4 +24,4 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r update_requirements.txt
-        python update.py
+        python update.py -refresh 1


### PR DESCRIPTION
**Key Changes**

1. `.github/workflows/refresh_statcast_data.yml`

This new workflow will run the update.py script with the `-refresh` flag, which will re scrape all the pitches and update the HF dataset. This was implemented because sometime statcast will change past data like pitch types, among other things.

This workflow is scheduled to run once per week, during all times of the year.

2. `.github/workflows/update_statcast_data.yml`

This existing workflow was updated to run daily during the months of 3-11. 